### PR TITLE
Update builder version 1.0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
   - docker info
   - docker version
   - df -kh
-  - wget https://github.com/CloudSlang/cloud-slang/releases/download/cloudslang-1.0.9/cslang-builder.zip
+  - wget https://github.com/CloudSlang/cloud-slang/releases/download/cloudslang-1.0.10/cslang-builder.zip
   - unzip -q cslang-builder.zip
   - chmod +x cslang-builder/bin/cslang-builder
   - ./cslang-builder/bin/cslang-builder -ts ${SUITE},\!default -cov -des -cs

--- a/circle.yml
+++ b/circle.yml
@@ -79,7 +79,7 @@ dependencies:
         fi
       : parallel: true
     - ? > ### every machine
-        wget https://github.com/CloudSlang/cloud-slang/releases/download/cloudslang-1.0.9/cslang-builder.zip
+        wget https://github.com/CloudSlang/cloud-slang/releases/download/cloudslang-1.0.10/cslang-builder.zip
         && unzip cslang-builder.zip
         && chmod +x cslang-builder/bin/cslang-builder
         && mkdir cslang-builder/lib/Lib


### PR DESCRIPTION
Score:
•	Same version: 0.3.44
CloudSlang:
•	https://github.com/CloudSlang/cloud-slang/pull/1005 - Fix file name for builder
•	https://github.com/CloudSlang/cloud-slang/pull/1013 - Spring IO Upgrades
GH link: https://github.com/CloudSlang/cloud-slang/releases/tag/cloudslang-1.0.10 


Signed-off-by: Levente Bonczidai <levente.bonczidai@hpe.com>