### PR TITLE
Update Google cloud compute engine.

### DIFF
--- a/content/io/cloudslang/google/compute/compute_engine/disks/attach_disk_to_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/disks/attach_disk_to_instance.sl
@@ -10,9 +10,6 @@
 #! @input instance_name: The name that the new instance will have.
 #!                       Example: 'instance-1234'
 #! @input source: A valid partial or full URL to an existing Persistent Disk resource.
-#! @input boot: Indicates that this is a boot disk. The virtual machine will use the first
-#!              partition of the disk for its root filesystem.
-#!              Optional
 #! @input mode: The mode in which to attach the disk to the instance.
 #!              Valid: 'READ_WRITE', 'READ_ONLY'
 #!              Default: 'READ_WRITE'
@@ -28,13 +25,20 @@
 #!                     in the form persistent-disks-x, where x is a number assigned by Google Compute Engine.
 #!                     This field is only applicable for persistent disks.
 #!                     Optional
-#! @input interface: Specifies the disk interface to use for attaching this disk.
-#!                   Note: Persistent disks must always use SCSI and the request will fail if you attempt to
-#!                   attach a persistent disk in any other format than SCSI. Local SSDs can use either
-#!                   NVME or SCSI.
-#!                   Valid: 'SCSI', 'NVME'
-#!                   Default: 'SCSI'
-#!                   Optional
+#! @input async: Boolean specifying whether the operation to run sync or async.
+#!               Valid: 'true', 'false'
+#!               Default: 'true'
+#!               Optional
+#! @input timeout: The time, in seconds, to wait for a response if the async input is set to "false".
+#!                 If the value is 0, the operation will wait until zone operation progress is 100.
+#!                 Valid: Any positive number including 0.
+#!                 Default: '30'
+#!                 Optional
+#! @input polling_interval: The time, in seconds, to wait before a new request that verifies if the operation finished
+#!                          is executed, if the async input is set to "false".
+#!                          Valid values: Any positive number including 0.
+#!                          Default: '1'
+#!                          Optional
 #! @input proxy_host: Proxy server used to access the provider services.
 #!                    Optional
 #! @input proxy_port: Proxy server port used to access the provider services.
@@ -53,13 +57,18 @@
 #! @output return_result: Contains the ZoneOperation resource, as a JSON object.
 #! @output exception: Exception if there was an error when executing, empty otherwise.
 #! @output zone_operation_name: Contains the ZoneOperation name, if the returnCode is '0', otherwise it is empty.
+#! @output instance_name_out: The name of the instance.
+#! @output instance_details: Details of the instance.
+#! @output disks: The disks attached to the instance.
+#! @output status: The status of the operation if async is true, otherwise the status of the instance.
+#! @output device_name_out: The name of the attached instance.
 #!
 #! @result SUCCESS: The request to attach the Disk to an Instance was successfully sent.
 #! @result FAILURE: An error occurred while trying to send the request.
 #!!#
 ########################################################################################################################
 
-namespace: io.cloudslang.google.compute.compute_engine.instances
+namespace: io.cloudslang.google.compute.compute_engine.disks
 
 operation: 
   name: attach_disk_to_instance
@@ -84,8 +93,6 @@ operation:
         required: false 
         private: true 
     - source    
-    - boot:  
-        required: false  
     - mode:
         default: 'READ_WRITE'
         required: false  
@@ -101,11 +108,21 @@ operation:
     - deviceName: 
         default: ${get('device_name', '')}  
         required: false 
-        private: true 
-    - interface:
-        default: 'SCSI'
-        required: false  
-    - proxy_host:  
+        private: true
+    - async:
+        default: 'true'
+        required: false
+    - timeout:
+        default: '30'
+        required: false
+    - polling_interval:
+        default: '1'
+        required: false
+    - pollingInterval:
+        default: ${get('polling_interval', '')}
+        required: false
+        private: true
+    - proxy_host:
         required: false  
     - proxyHost: 
         default: ${get('proxy_host', '')}  
@@ -140,15 +157,20 @@ operation:
         private: true 
     
   java_action: 
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
-    class_name: 'io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesAttachDisk'
-    method_name: 'execute'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    class_name: io.cloudslang.content.google.actions.compute.compute_engine.disks.AttachDisk
+    method_name: execute
   
   outputs: 
     - return_code: ${returnCode}
     - return_result: ${returnResult}
     - exception: ${get('exception', '')}
-    - zone_operation_name: ${zoneOperationName} 
+    - zone_operation_name: ${zoneOperationName}
+    - instance_name_out: ${get('instanceName', '')}
+    - instance_details: ${get('instanceDetails', '')}
+    - disks
+    - status
+    - device_name_out: ${get('deviceName', '')}
   
   results: 
     - SUCCESS: ${returnCode=='0'} 

--- a/content/io/cloudslang/google/compute/compute_engine/disks/attach_disk_to_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/disks/attach_disk_to_instance.sl
@@ -170,7 +170,7 @@ operation:
         private: true 
     
   java_action: 
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.disks.AttachDisk
     method_name: execute
   

--- a/content/io/cloudslang/google/compute/compute_engine/disks/delete_disk.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/disks/delete_disk.sl
@@ -142,7 +142,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.disks.DisksDelete
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/disks/detach_disk_from_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/disks/detach_disk_from_instance.sl
@@ -1,24 +1,15 @@
-#   (c) Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
-#   All rights reserved. This program and the accompanying materials
-#   are made available under the terms of the Apache License v2.0 which accompany this distribution.
-#
-#   The Apache License is available at
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
 ########################################################################################################################
 #!!
-#! @description: This operation can be used to delete a Disk resource. The operation returns a ZoneOperation resource as a
-#!               JSON object, that can be used to retrieve the status and progress of the ZoneOperation, using the
-#!               ZoneOperationsGet operation.
+#! @description: This operation deletes a disk resource from the specified project using the data included as inputs.
 #!
-#! @input project_id: Google Cloud project id.
+#! @input project_id: Google Cloud project name.
 #!                    Example: 'example-project-a'
-#! @input zone: The name of the zone where the Disk resource is located.
+#! @input zone: The name of the zone in which the instance lives.
 #!              Examples: 'us-central1-a', 'us-central1-b', 'us-central1-c'
-#! @input disk_name: Name of the Disk resource to delete.
-#!                   Example: 'disk-1'
-#! @input access_token: The access token returned by the GetAccessToken operation, with at least the
-#!                      following scope: 'https://www.googleapis.com/auth/compute'.
+#! @input access_token: The access token from get_access_token.
+#! @input instance_name: The name that the new instance will have.
+#!                       Example: 'instance-1234'
+#! @input device_name: The disk device name to detach.
 #! @input async: Boolean specifying whether the operation to run sync or async.
 #!               Valid: 'true', 'false'
 #!               Default: 'true'
@@ -47,46 +38,52 @@
 #!                      Default: 'true'
 #!                      Optional
 #!
-#! @output return_result: Contains the ZoneOperation resource, as a JSON object.
 #! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
+#! @output return_result: Contains the ZoneOperation resource, as a JSON object.
 #! @output exception: Exception if there was an error when executing, empty otherwise.
 #! @output zone_operation_name: Contains the ZoneOperation name, if the returnCode is '0', otherwise it is empty.
+#! @output instance_name_out: The name of the instance.
+#! @output instance_details: Details of the instance.
+#! @output disks: The disks attached to the instance.
 #! @output status: The status of the operation if async is true, otherwise the status of the instance.
-#! @output disk_name_out: The name of the attached instance.
 #!
-#! @result SUCCESS: The request for the Disk to be deleted was successfully sent.
+#! @result SUCCESS: The request to detach the Disk from an Instance was successfully sent.
 #! @result FAILURE: An error occurred while trying to send the request.
-#!
 #!!#
 ########################################################################################################################
 
 namespace: io.cloudslang.google.compute.compute_engine.disks
 
-operation:
-  name: delete_disk
-
-  inputs:
-    - project_id
-    - projectId:
-        default: ${get('project_id', '')}
-        required: false
-        private: true
-    - zone
-    - disk_name
-    - diskName:
-        default: ${get('disk_name', '')}
-        required: false
-        private: true
-    - access_token:
+operation: 
+  name: detach_disk_from_instance
+  
+  inputs: 
+    - access_token:    
         sensitive: true
-    - accessToken:
-        default: ${get('access_token', '')}
-        required: false
-        private: true
+    - accessToken: 
+        default: ${get('access_token', '')}  
+        required: false 
+        private: true 
         sensitive: true
+    - project_id    
+    - projectId: 
+        default: ${get('project_id', '')}  
+        required: false 
+        private: true 
+    - zone    
+    - instance_name    
+    - instanceName: 
+        default: ${get('instance_name', '')}  
+        required: false 
+        private: true 
+    - device_name    
+    - deviceName: 
+        default: ${get('device_name', '')}  
+        required: false 
+        private: true
     - async:
-        default: 'true'
-        required: false
+          default: 'true'
+          required: false
     - timeout:
         default: '30'
         required: false
@@ -134,20 +131,22 @@ operation:
         default: ${get('pretty_print', '')}
         required: false
         private: true
-
-  java_action:
+    
+  java_action: 
     gav: 'io.cloudslang.content:cs-google:0.4.1'
-    class_name: io.cloudslang.content.google.actions.compute.compute_engine.disks.DisksDelete
+    class_name: io.cloudslang.content.google.actions.compute.compute_engine.disks.DetachDisk
     method_name: execute
-
-  outputs:
+  
+  outputs: 
     - return_code: ${returnCode}
     - return_result: ${returnResult}
     - exception: ${get('exception', '')}
     - zone_operation_name: ${zoneOperationName}
+    - instance_name_out: ${get('instanceName', '')}
+    - instance_details: ${get('instanceDetails', '')}
+    - disks
     - status
-    - disk_name_out: ${get('disk_name', '')}
-
-  results:
-    - SUCCESS: ${returnCode=='0'}
+  
+  results: 
+    - SUCCESS: ${returnCode=='0'} 
     - FAILURE

--- a/content/io/cloudslang/google/compute/compute_engine/disks/detach_disk_from_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/disks/detach_disk_from_instance.sl
@@ -146,7 +146,7 @@ operation:
         private: true
     
   java_action: 
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.disks.DetachDisk
     method_name: execute
   

--- a/content/io/cloudslang/google/compute/compute_engine/disks/get_disk.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/disks/get_disk.sl
@@ -109,7 +109,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.disks.DisksGet
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/disks/get_disk.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/disks/get_disk.sl
@@ -103,7 +103,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.disks.DisksGet
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/disks/insert_disk.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/disks/insert_disk.sl
@@ -255,7 +255,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.disks.DisksInsert
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/disks/insert_disk.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/disks/insert_disk.sl
@@ -68,6 +68,20 @@
 #!                             be encrypted using an automatically generated key and you do not need to provide
 #!                             a key to use the disk later.
 #!                             Optional
+#! @input async: Boolean specifying whether the operation to run sync or async.
+#!               Valid: 'true', 'false'
+#!               Default: 'true'
+#!               Optional
+#! @input timeout: The time, in seconds, to wait for a response if the async input is set to "false".
+#!                 If the value is 0, the operation will wait until zone operation progress is 100.
+#!                 Valid: Any positive number including 0.
+#!                 Default: '30'
+#!                 Optional
+#! @input polling_interval: The time, in seconds, to wait before a new request that verifies if the operation finished
+#!                          is executed, if the async input is set to "false".
+#!                          Valid values: Any positive number including 0.
+#!                          Default: '1'
+#!                          Optional
 #! @input proxy_host: Proxy server used to access the provider services.
 #!                    Optional
 #! @input proxy_port: Proxy server port used to access the provider services.
@@ -86,6 +100,11 @@
 #! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
 #! @output exception: Exception if there was an error when executing, empty otherwise.
 #! @output zone_operation_name: Contains the ZoneOperation name, if the returnCode is '0', otherwise it is empty.
+#! @output disk_id: The id of the new disk.
+#! @output disk_name_out: The name of the new disk.
+#! @output disk_size_out: The size in GB of the new disk.
+#! @output status: The status of the operation if async is true, otherwise the status of the instance.
+#! @output zone_out: The zone in which the instance is.
 #!
 #! @result SUCCESS: The request for the Disk to be inserted was successfully sent.
 #! @result FAILURE: An error occurred while trying to send the request.
@@ -178,6 +197,19 @@ operation:
         default: ${get('disk_encryption_key', '')}
         required: false
         private: true
+    - async:
+        default: 'true'
+        required: false
+    - timeout:
+        default: '30'
+        required: false
+    - polling_interval:
+        default: '1'
+        required: false
+    - pollingInterval:
+        default: ${get('polling_interval', '')}
+        required: false
+        private: true
     - proxy_host:
         default: ''
         required: false
@@ -217,7 +249,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.disks.DisksInsert
     method_name: execute
 
@@ -226,6 +258,11 @@ operation:
     - return_result: ${returnResult}
     - exception: ${get('exception', '')}
     - zone_operation_name: ${zoneOperationName}
+    - disk_id: ${get('diskId', '')}
+    - disk_name_out: ${get('diskName', '')}
+    - disk_size_out: ${get('diskSize', '')}
+    - status
+    - zone_out: ${get('zone','')}
 
   results:
     - SUCCESS: ${returnCode=='0'}

--- a/content/io/cloudslang/google/compute/compute_engine/disks/list_disks.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/disks/list_disks.sl
@@ -132,7 +132,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.disks.DisksList
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/disks/list_disks.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/disks/list_disks.sl
@@ -138,7 +138,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.disks.DisksList
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/delete_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/delete_instance.sl
@@ -18,6 +18,20 @@
 #! @input instance_name: Name of the Instance resource to delete.
 #!                       Example: 'operation-1234'
 #! @input access_token: The access token from get_access_token.
+#! @input async: Boolean specifying whether the operation to run sync or async.
+#!               Valid: 'true', 'false'
+#!               Default: 'true'
+#!               Optional
+#! @input timeout: The time, in seconds, to wait for a response if the async input is set to "false".
+#!                 If the value is 0, the operation will wait until zone operation progress is 100.
+#!                 Valid: Any positive number including 0.
+#!                 Default: '30'
+#!                 Optional
+#! @input polling_interval: The time, in seconds, to wait before a new request that verifies if the operation finished
+#!                          is executed, if the async input is set to "false".
+#!                          Valid values: Any positive number including 0.
+#!                          Default: '1'
+#!                          Optional
 #! @input proxy_host: Proxy server used to access the provider services.
 #!                    Optional
 #! @input proxy_port: Proxy server port used to access the provider services.
@@ -36,6 +50,8 @@
 #! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
 #! @output exception: Exception if there was an error when executing, empty otherwise.
 #! @output zone_operation_name: Contains the ZoneOperation name, if the returnCode is '0', otherwise it is empty.
+#! @output instance_name_out: The name of the newly created instance.
+#! @output status: The status of the newly created instance if async is false, otherwise the status of the ZoneOperation.
 #!
 #! @result SUCCESS: The request for the Instance to be deleted was successfully sent.
 #! @result FAILURE: An error occurred while trying to send the request.
@@ -67,6 +83,19 @@ operation:
         required: false
         private: true
         sensitive: true
+    - async:
+        default: 'true'
+        required: false
+    - timeout:
+        default: '30'
+        required: false
+    - polling_interval:
+        default: '1'
+        required: false
+    - pollingInterval:
+        default: ${get('polling_interval', '')}
+        required: false
+        private: true
     - proxy_host:
         default: ''
         required: false
@@ -115,6 +144,8 @@ operation:
     - return_result: ${returnResult}
     - exception: ${get('exception', '')}
     - zone_operation_name: ${zoneOperationName}
+    - instance_name_out: ${get('instanceName', '')}
+    - status
 
   results:
     - SUCCESS: ${returnCode=='0'}

--- a/content/io/cloudslang/google/compute/compute_engine/instances/delete_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/delete_instance.sl
@@ -106,7 +106,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesDelete
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/delete_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/delete_instance.sl
@@ -141,7 +141,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesDelete
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/get_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/get_instance.sl
@@ -103,7 +103,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesGet
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/get_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/get_instance.sl
@@ -33,6 +33,14 @@
 #! @output return_result: A JSON containing the Instance resource information.
 #! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
 #! @output exception: Exception if there was an error when executing, empty otherwise.
+#! @output instance_id: The id of the instance.
+#! @output instance_name_out: The name of the instance.
+#! @output internal_ips: The internal IPs of the instance.
+#! @output external_ips: The external IPs of the instance.
+#! @output status: The status of the instance.
+#! @output metadata: The metadata of the instance.
+#! @output tags: The tags of the instance.
+#! @output disks: The attached disks of the instance.
 #!
 #! @result SUCCESS: The Instance was found and successfully retrieved.
 #! @result FAILURE: The Instance was not found or some inputs were given incorrectly
@@ -111,6 +119,14 @@ operation:
     - return_code: ${returnCode}
     - return_result: ${returnResult}
     - exception: ${get('exception', '')}
+    - instance_id: ${get('instanceId'. '')}
+    - instance_name_out: ${get('instanceName', '')}
+    - internal_ips: ${get('internalIps', '')}
+    - external_ips: ${get('externalIps', '')}
+    - status
+    - metadata
+    - tags
+    - disks
 
   results:
     - SUCCESS: ${returnCode=='0'}

--- a/content/io/cloudslang/google/compute/compute_engine/instances/get_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/get_instance.sl
@@ -117,7 +117,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesGet
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/get_serial_port_output.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/get_serial_port_output.sl
@@ -7,31 +7,25 @@
 #
 ########################################################################################################################
 #!!
-#! @description: This operation can be used to stop an Instance resource. The operation returns a ZoneOperation resource
-#!               as a JSON object, that can be used to retrieve the status and progress of the ZoneOperation, using the
-#!               ZoneOperationsGet operation.
+#! @description: This operation can be used to retrieve data from a port.
 #!
 #! @input project_id: Google Cloud project name.
 #!                    Example: 'example-project-a'
 #! @input zone: The name of the zone in which the instance lives.
 #!              Examples: 'us-central1-a', 'us-central1-b', 'us-central1-c'
-#! @input instance_name: Name of the Instance resource to stop.
+#! @input instance_name: Name of the Instance resource to get.
 #!                       Example: 'operation-1234'
+#! @input console_port: Specifies which COM or serial port to retrieve data from.
+#!                      Valid: an integer between 1 and 4 (inclusive)
+#!                      Default: '1'
+#!                      Optional
+#! @input start_index: The byte position from which to return the output. Use this to page through output
+#!                     when the output is too large to return in a single request. For the initial request, leave
+#!                     this field unspecified. For subsequent calls, this field should be set to the next value
+#!                     returned in the previous call.
+#!                     Default: '0'
+#!                     Optional
 #! @input access_token: The access token from get_access_token.
-#! @input async: Boolean specifying whether the operation to run sync or async.
-#!               Valid: 'true', 'false'
-#!               Default: 'true'
-#!               Optional
-#! @input timeout: The time, in seconds, to wait for a response if the async input is set to "false".
-#!                 If the value is 0, the operation will wait until zone operation progress is 100.
-#!                 Valid: Any positive number including 0.
-#!                 Default: '30'
-#!                 Optional
-#! @input polling_interval: The time, in seconds, to wait before a new request that verifies if the operation finished
-#!                          is executed, if the async input is set to "false".
-#!                          Valid values: Any positive number including 0.
-#!                          Default: '1'
-#!                          Optional
 #! @input proxy_host: Proxy server used to access the provider services.
 #!                    Optional
 #! @input proxy_port: Proxy server port used to access the provider services.
@@ -46,16 +40,13 @@
 #!                      Default: 'true'
 #!                      Optional
 #!
-#! @output return_result: Contains the ZoneOperation resource, as a JSON object.
+#! @output return_result: A string containing the read data from the port.
 #! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
 #! @output exception: Exception if there was an error when executing, empty otherwise.
-#! @output zone_operation_name: Contains the ZoneOperation name, if the returnCode is '0', otherwise it is empty.
-#! @output instance_name_out: The name of the instance.
-#! @output instance_details: Details about the instance if async is false.
-#! @output status: The status of the instance if async is false, otherwise the status of the ZoneOperation.
+#! @output next_index: The position of the last byte read.
 #!
-#! @result SUCCESS: The request for the Instance to stop was successfully sent.
-#! @result FAILURE: An error occurred while trying to send the request.
+#! @result SUCCESS: The Instance was found and successfully retrieved.
+#! @result FAILURE: The Instance was not found or some inputs were given incorrectly
 #!
 #!!#
 ########################################################################################################################
@@ -63,7 +54,7 @@
 namespace: io.cloudslang.google.compute.compute_engine.instances
 
 operation:
-  name: stop_instance
+  name: get_serial_port_output
 
   inputs:
     - project_id
@@ -77,6 +68,20 @@ operation:
         default: ${get('instance_name', '')}
         required: false
         private: true
+    - console_port:
+        default: '1'
+        required: false
+    - consolePort:
+        default: ${get('console_port', '')}
+        required: false
+        private: true
+    - start_index:
+        default: '0'
+        required: false
+    - startIndex:
+        default: ${get('start_index', '')}
+        required: false
+        private: true
     - access_token:
         sensitive: true
     - accessToken:
@@ -84,19 +89,6 @@ operation:
         required: false
         private: true
         sensitive: true
-    - async:
-        default: 'true'
-        required: false
-    - timeout:
-        default: '30'
-        required: false
-    - polling_interval:
-        default: '1'
-        required: false
-    - pollingInterval:
-        default: ${get('polling_interval', '')}
-        required: false
-        private: true
     - proxy_host:
         default: ''
         required: false
@@ -127,27 +119,17 @@ operation:
         required: false
         private: true
         sensitive: true
-    - pretty_print:
-        default: 'true'
-        required: false
-    - prettyPrint:
-        default: ${get('pretty_print', '')}
-        required: false
-        private: true
 
   java_action:
     gav: 'io.cloudslang.content:cs-google:0.4.1'
-    class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesStop
+    class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesGetSerialPortOutput
     method_name: execute
 
   outputs:
     - return_code: ${returnCode}
     - return_result: ${returnResult}
     - exception: ${get('exception', '')}
-    - zone_operation_name: ${zoneOperationName}
-    - instance_name_out: ${get('instanceName', '')}
-    - instance_details: ${get('instanceDetails', '')}
-    - status
+    - next_index: ${get('nextIndex', '')}
 
   results:
     - SUCCESS: ${returnCode=='0'}

--- a/content/io/cloudslang/google/compute/compute_engine/instances/get_serial_port_output.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/get_serial_port_output.sl
@@ -121,7 +121,7 @@ operation:
         sensitive: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesGetSerialPortOutput
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/insert_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/insert_instance.sl
@@ -395,7 +395,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesInsert
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/insert_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/insert_instance.sl
@@ -144,6 +144,20 @@
 #!                               Optional
 #! @input service_account_scopes: The list of scopes to be made available for this service account.
 #!                                Optional
+#! @input async: Boolean specifying whether the operation to run sync or async.
+#!               Valid: 'true', 'false'
+#!               Default: 'true'
+#!               Optional
+#! @input timeout: The time, in seconds, to wait for a response if the async input is set to "false".
+#!                 If the value is 0, the operation will wait until zone operation progress is 100.
+#!                 Valid: Any positive number including 0.
+#!                 Default: '30'
+#!                 Optional
+#! @input polling_interval: The time, in seconds, to wait before a new request that verifies if the operation finished
+#!                          is executed, if the async input is set to "false".
+#!                          Valid values: Any positive number including 0.
+#!                          Default: '1'
+#!                          Optional
 #! @input proxy_host: Proxy server used to access the provider services.
 #!                    Optional
 #! @input proxy_port: Proxy server port used to access the provider services.
@@ -161,6 +175,11 @@
 #! @output return_result: Contains the ZoneOperation resource, as a JSON object.
 #! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
 #! @output exception: Exception if there was an error when executing, empty otherwise.
+#! @output instance_id: The id of the instance if async is false.
+#! @output instance_name_out: The name of the instance.
+#! @output internal_ips: The internal IPs of the instance if async is false.
+#! @output external_ips: The external IPs of the instance if async is false.
+#! @output status: The status of the instance if async is false, otherwise the status of the ZoneOperation.
 #! @output zone_operation_name: Contains the ZoneOperation name, if the returnCode is '0', otherwise it is empty.
 #!
 #! @result SUCCESS: The request for the Instance to be inserted was successfully sent.
@@ -356,6 +375,19 @@ operation:
         default: ${get('service_account_scopes', '')}
         required: false
         private: true
+    - async:
+        default: 'true'
+        required: false
+    - timeout:
+        default: '30'
+        required: false
+    - polling_interval:
+        default: '1'
+        required: false
+    - pollingInterval:
+        default: ${get('polling_interval', '')}
+        required: false
+        private: true
     - proxy_host:
         default: ''
         required: false
@@ -400,9 +432,14 @@ operation:
     method_name: execute
 
   outputs:
-    - return_result: ${returnResult}
     - return_code: ${returnCode}
+    - return_result: ${returnResult}
     - exception: ${get('exception', '')}
+    - instance_id: ${get('instanceId'. '')}
+    - instance_name_out: ${get('instanceName', '')}
+    - internal_ips: ${get('internalIps', '')}
+    - external_ips: ${get('externalIps', '')}
+    - status
     - zone_operation_name: ${zoneOperationName}
 
   results:

--- a/content/io/cloudslang/google/compute/compute_engine/instances/insert_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/insert_instance.sl
@@ -433,7 +433,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesInsert
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/list_instances.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/list_instances.sl
@@ -132,7 +132,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesList
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/list_instances.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/list_instances.sl
@@ -138,7 +138,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesList
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/reset_windows_password.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/reset_windows_password.sl
@@ -139,7 +139,7 @@ operation:
         sensitive: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesResetWindowsPassword
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/reset_windows_password.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/reset_windows_password.sl
@@ -1,0 +1,154 @@
+#   (c) Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
+#   All rights reserved. This program and the accompanying materials
+#   are made available under the terms of the Apache License v2.0 which accompany this distribution.
+#
+#   The Apache License is available at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+########################################################################################################################
+#!!
+#! @description: This operation can be used to reset the password of a windows machine.
+#!
+#! @input project_id: Google Cloud project name.
+#!                    Example: 'example-project-a'
+#! @input zone: The name of the zone in which the instance lives.
+#!              Examples: 'us-central1-a', 'us-central1-b', 'us-central1-c'
+#! @input instance_name: Name of the Instance resource to delete.
+#!                       Example: 'operation-1234'
+#! @input access_token: The access token from get_access_token.
+#! @input username: Specify a username. If the the username does not exist, it will be created.
+#!                  Format: Must start with a lowercase letter, followed by 1-31 lowercase letters, numbers,
+#!                  or underscores
+#!                  Note: The format is not enforced since it may change or special rules may be added or removed
+#!                  depending on the OS.
+#! @input email: The email for the username for which the password is reset.
+#!               Optional
+#! @input sync_time: The maximum number of seconds to allow to differ between the time on the client
+#!                   and time on the server.
+#!                   Valid: Any positive number
+#!                   Default: '300'
+#!                   Optional
+#! @input timeout: The time, in seconds, to wait for a response if the async input is set to "false".
+#!                 If the value is 0, the operation will wait until zone operation progress is 100.
+#!                 Valid: Any positive number including 0.
+#!                 Default: '30'
+#!                 Optional
+#! @input polling_interval: The time, in seconds, to wait before a new request that verifies if the operation finished
+#!                          is executed, if the async input is set to "false".
+#!                          Valid values: Any positive number including 0.
+#!                          Default: '1'
+#!                          Optional
+#! @input proxy_host: Proxy server used to access the provider services.
+#!                    Optional
+#! @input proxy_port: Proxy server port used to access the provider services.
+#!                    Default: '8080'
+#!                    Optional
+#! @input proxy_username: Proxy server user name.
+#!                        Optional
+#! @input proxy_password: Proxy server password associated with the <proxy_username> input value.
+#!                        Optional
+#! @input pretty_print: Whether to format the resulting JSON.
+#!                      Valid: 'true', 'false'
+#!                      Default: 'true'
+#!                      Optional
+#!
+#! @output return_result: Contains the ZoneOperation resource, as a JSON object.
+#! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
+#! @output exception: Exception if there was an error when executing, empty otherwise.
+#! @output password: The newly generated password for the username.
+#!
+#! @result SUCCESS: The request for the Instance to be deleted was successfully sent.
+#! @result FAILURE: An error occurred while trying to send the request.
+#!
+#!!#
+########################################################################################################################
+
+namespace: io.cloudslang.google.compute.compute_engine.instances
+
+operation:
+  name: reset_windows_password
+
+  inputs:
+    - project_id
+    - projectId:
+        default: ${get('project_id', '')}
+        required: false
+        private: true
+    - zone
+    - instance_name
+    - instanceName:
+        default: ${get('instance_name', '')}
+        required: false
+        private: true
+    - access_token:
+        sensitive: true
+    - accessToken:
+        default: ${get('access_token', '')}
+        required: false
+        private: true
+        sensitive: true
+    - username
+    - email:
+        required: false
+    - sync_time:
+        default: '300'
+        required: false
+    - syncTime:
+        default: ${get('sync_time', '')}
+        required: false
+        private: true
+    - timeout:
+        default: '30'
+        required: false
+    - polling_interval:
+        default: '1'
+        required: false
+    - pollingInterval:
+        default: ${get('polling_interval', '')}
+        required: false
+        private: true
+    - proxy_host:
+        default: ''
+        required: false
+    - proxyHost:
+        default: ${get('proxy_host', '')}
+        required: false
+        private: true
+    - proxy_port:
+        default: '8080'
+        required: false
+    - proxyPort:
+        default: ${get('proxy_port', '')}
+        required: false
+        private: true
+    - proxy_username:
+        default: ''
+        required: false
+    - proxyUsername:
+        default: ${get('proxy_username', '')}
+        required: false
+        private: true
+    - proxy_password:
+        default: ''
+        required: false
+        sensitive: true
+    - proxyPassword:
+        default: ${get('proxy_password', '')}
+        required: false
+        private: true
+        sensitive: true
+
+  java_action:
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesResetWindowsPassword
+    method_name: execute
+
+  outputs:
+    - return_code: ${returnCode}
+    - return_result: ${returnResult}
+    - exception: ${get('exception', '')}
+    - password
+
+  results:
+    - SUCCESS: ${returnCode=='0'}
+    - FAILURE

--- a/content/io/cloudslang/google/compute/compute_engine/instances/restart_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/restart_instance.sl
@@ -106,7 +106,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesRestart
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/restart_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/restart_instance.sl
@@ -18,6 +18,20 @@
 #! @input instance_name: Name of the Instance resource to restart.
 #!                       Example: 'operation-1234'
 #! @input access_token: The access token from get_access_token.
+#! @input async: Boolean specifying whether the operation to run sync or async.
+#!               Valid: 'true', 'false'
+#!               Default: 'true'
+#!               Optional
+#! @input timeout: The time, in seconds, to wait for a response if the async input is set to "false".
+#!                 If the value is 0, the operation will wait until zone operation progress is 100.
+#!                 Valid: Any positive number including 0.
+#!                 Default: '30'
+#!                 Optional
+#! @input polling_interval: The time, in seconds, to wait before a new request that verifies if the operation finished
+#!                          is executed, if the async input is set to "false".
+#!                          Valid values: Any positive number including 0.
+#!                          Default: '1'
+#!                          Optional
 #! @input proxy_host: Proxy server used to access the provider services.
 #!                    Optional
 #! @input proxy_port: Proxy server port used to access the provider services.
@@ -36,6 +50,9 @@
 #! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
 #! @output exception: Exception if there was an error when executing, empty otherwise.
 #! @output zone_operation_name: Contains the ZoneOperation name, if the returnCode is '0', otherwise it is empty.
+#! @output instance_name_out: The name of the instance.
+#! @output instance_details: Details about the instance if async is false.
+#! @output status: The status of the instance if async is false, otherwise the status of the ZoneOperation.
 #!
 #! @result SUCCESS: The request for the Instance to restart was successfully sent.
 #! @result FAILURE: An error occurred while trying to send the request.
@@ -67,6 +84,19 @@ operation:
         required: false
         private: true
         sensitive: true
+    - async:
+        default: 'true'
+        required: false
+    - timeout:
+        default: '30'
+        required: false
+    - polling_interval:
+        default: '1'
+        required: false
+    - pollingInterval:
+        default: ${get('polling_interval', '')}
+        required: false
+        private: true
     - proxy_host:
         default: ''
         required: false
@@ -115,6 +145,9 @@ operation:
     - return_result: ${returnResult}
     - exception: ${get('exception', '')}
     - zone_operation_name: ${zoneOperationName}
+    - instance_name_out: ${get('instanceName', '')}
+    - instance_details: ${get('instanceDetails', '')}
+    - status
 
   results:
     - SUCCESS: ${returnCode=='0'}

--- a/content/io/cloudslang/google/compute/compute_engine/instances/restart_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/restart_instance.sl
@@ -142,7 +142,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesRestart
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/set_instance_metadata.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/set_instance_metadata.sl
@@ -30,6 +30,20 @@
 #!                           Optional
 #! @input items_delimiter: The delimiter to split the <items_keys_list> and <items_values_list>
 #!                         Default: ','
+#! @input async: Boolean specifying whether the operation to run sync or async.
+#!               Valid: 'true', 'false'
+#!               Default: 'true'
+#!               Optional
+#! @input timeout: The time, in seconds, to wait for a response if the async input is set to "false".
+#!                 If the value is 0, the operation will wait until zone operation progress is 100.
+#!                 Valid: Any positive number including 0.
+#!                 Default: '30'
+#!                 Optional
+#! @input polling_interval: The time, in seconds, to wait before a new request that verifies if the operation finished
+#!                          is executed, if the async input is set to "false".
+#!                          Valid values: Any positive number including 0.
+#!                          Default: '1'
+#!                          Optional
 #! @input proxy_host: Proxy server used to access the provider services.
 #!                    Optional
 #! @input proxy_port: Proxy server port used to access the provider services.
@@ -48,6 +62,10 @@
 #! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
 #! @output exception: Exception if there was an error when executing, empty otherwise.
 #! @output zone_operation_name: Contains the ZoneOperation name, if the returnCode is '0', otherwise it is empty.
+#! @output instance_name_out: The name of the instance.
+#! @output instance_details: Details about the instance if async is false.
+#! @output status: The status of the instance if async is false, otherwise the status of the ZoneOperation.
+#! @output metadata: All the metadata assigned to the instance.
 #!
 #! @result SUCCESS: The request to set the Instance metadata was successfully sent.
 #! @result FAILURE: An error occurred while trying to send the request.
@@ -100,6 +118,19 @@ operation:
         default: ${get('items_delimiter', '')}
         required: false
         private: true
+    - async:
+        default: 'true'
+        required: false
+    - timeout:
+        default: '30'
+        required: false
+    - polling_interval:
+        default: '1'
+        required: false
+    - pollingInterval:
+        default: ${get('polling_interval', '')}
+        required: false
+        private: true
     - proxy_host:
         default: ''
         required: false
@@ -148,6 +179,10 @@ operation:
     - return_result: ${returnResult}
     - exception: ${get('exception', '')}
     - zone_operation_name: ${zoneOperationName}
+    - instance_name_out: ${get('instanceName', '')}
+    - instance_details: ${get('instanceDetails', '')}
+    - status
+    - metadata
 
   results:
     - SUCCESS: ${returnCode=='0'}

--- a/content/io/cloudslang/google/compute/compute_engine/instances/set_instance_metadata.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/set_instance_metadata.sl
@@ -176,7 +176,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesSetMetadata
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/set_instance_metadata.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/set_instance_metadata.sl
@@ -139,7 +139,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesSetMetadata
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/set_instance_tags.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/set_instance_tags.sl
@@ -160,7 +160,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesSetTags
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/set_instance_tags.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/set_instance_tags.sl
@@ -21,6 +21,20 @@
 #! @input tags_delimiter: Delimiter used for the list of tags from <tags_list> param.
 #!                        Default: ','
 #! @input access_token: The access token from get_access_token.
+#! @input async: Boolean specifying whether the operation to run sync or async.
+#!               Valid: 'true', 'false'
+#!               Default: 'true'
+#!               Optional
+#! @input timeout: The time, in seconds, to wait for a response if the async input is set to "false".
+#!                 If the value is 0, the operation will wait until zone operation progress is 100.
+#!                 Valid: Any positive number including 0.
+#!                 Default: '30'
+#!                 Optional
+#! @input polling_interval: The time, in seconds, to wait before a new request that verifies if the operation finished
+#!                          is executed, if the async input is set to "false".
+#!                          Valid values: Any positive number including 0.
+#!                          Default: '1'
+#!                          Optional
 #! @input proxy_host: Proxy server used to access the provider services.
 #!                    Optional
 #! @input proxy_port: Proxy server port used to access the provider services.
@@ -39,6 +53,10 @@
 #! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
 #! @output exception: Exception if there was an error when executing, empty otherwise.
 #! @output zone_operation_name: Contains the ZoneOperation name, if the returnCode is '0', otherwise it is empty.
+#! @output instance_name_out: The name of the instance.
+#! @output instance_details: Details about the instance if async is false.
+#! @output status: The status of the instance if async is false, otherwise the status of the ZoneOperation.
+#! @output tags: All the tags assigned to the instance
 #!
 #! @result SUCCESS: The request to set the Instance tags was successfully sent.
 #! @result FAILURE: An error occurred while trying to send the request.
@@ -84,6 +102,19 @@ operation:
         required: false
         private: true
         sensitive: true
+    - async:
+        default: 'true'
+        required: false
+    - timeout:
+        default: '30'
+        required: false
+    - polling_interval:
+        default: '1'
+        required: false
+    - pollingInterval:
+        default: ${get('polling_interval', '')}
+        required: false
+        private: true
     - proxy_host:
         default: ''
         required: false
@@ -132,6 +163,10 @@ operation:
     - return_result: ${returnResult}
     - exception: ${get('exception', '')}
     - zone_operation_name: ${zoneOperationName}
+    - instance_name_out: ${get('instanceName', '')}
+    - instance_details: ${get('instanceDetails', '')}
+    - status
+    - tags
 
   results:
     - SUCCESS: ${returnCode=='0'}

--- a/content/io/cloudslang/google/compute/compute_engine/instances/set_instance_tags.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/set_instance_tags.sl
@@ -123,7 +123,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesSetTags
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/set_machine_type.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/set_machine_type.sl
@@ -7,7 +7,7 @@
 #
 ########################################################################################################################
 #!!
-#! @description: This operation can be used to set the machine type of a stoped instance.
+#! @description: This operation can be used to set the machine type of a stopped instance.
 #!
 #! @input project_id: Google Cloud project name.
 #!                    Example: 'example-project-a'

--- a/content/io/cloudslang/google/compute/compute_engine/instances/set_machine_type.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/set_machine_type.sl
@@ -143,7 +143,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesSetMachineType
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/set_machine_type.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/set_machine_type.sl
@@ -1,0 +1,163 @@
+#   (c) Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
+#   All rights reserved. This program and the accompanying materials
+#   are made available under the terms of the Apache License v2.0 which accompany this distribution.
+#
+#   The Apache License is available at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+########################################################################################################################
+#!!
+#! @description: This operation can be used to set the machine type of a stoped instance.
+#!
+#! @input project_id: Google Cloud project name.
+#!                    Example: 'example-project-a'
+#! @input zone: The name of the zone in which the instance lives.
+#!              Examples: 'us-central1-a', 'us-central1-b', 'us-central1-c'
+#! @input instance_name: Name of the Instance resource to set the machine type.
+#!                       Example: 'operation-1234'
+#! @input access_token: The access token from get_access_token.
+#! @input machine_type: Full or partial URL of the machine type resource to use for this instance, in the format:
+#!                      "zones/zone/machineTypes/machine-type".
+#!                      Example: "zones/us-central1-f/machineTypes/n1-standard-1"
+#! @input async: Boolean specifying whether the operation to run sync or async.
+#!               Valid: 'true', 'false'
+#!               Default: 'true'
+#!               Optional
+#! @input timeout: The time, in seconds, to wait for a response if the async input is set to "false".
+#!                 If the value is 0, the operation will wait until zone operation progress is 100.
+#!                 Valid: Any positive number including 0.
+#!                 Default: '30'
+#!                 Optional
+#! @input polling_interval: The time, in seconds, to wait before a new request that verifies if the operation finished
+#!                          is executed, if the async input is set to "false".
+#!                          Valid values: Any positive number including 0.
+#!                          Default: '1'
+#!                          Optional
+#! @input proxy_host: Proxy server used to access the provider services.
+#!                    Optional
+#! @input proxy_port: Proxy server port used to access the provider services.
+#!                    Default: '8080'
+#!                    Optional
+#! @input proxy_username: Proxy server user name.
+#!                        Optional
+#! @input proxy_password: Proxy server password associated with the <proxy_username> input value.
+#!                        Optional
+#! @input pretty_print: Whether to format the resulting JSON.
+#!                      Valid: 'true', 'false'
+#!                      Default: 'true'
+#!                      Optional
+#!
+#! @output return_result: Contains the ZoneOperation resource, as a JSON object.
+#! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
+#! @output exception: Exception if there was an error when executing, empty otherwise.
+#! @output status: The status of the instance if async is false, otherwise the status of the ZoneOperation.
+#! @output zone_operation_name:  Contains the ZoneOperation name, if the returnCode is '0', otherwise it is empty.
+#! @output instance_name_out: The name of the instance.
+#! @output instance_details: Details about the instance.
+#! @output machine_type_out: The machine type of the instance.
+#!
+#! @result SUCCESS: The request for the Instance to be deleted was successfully sent.
+#! @result FAILURE: An error occurred while trying to send the request.
+#!
+#!!#
+########################################################################################################################
+
+namespace: io.cloudslang.google.compute.compute_engine.instances
+
+operation:
+  name: set_machine_type
+
+  inputs:
+    - project_id
+    - projectId:
+        default: ${get('project_id', '')}
+        required: false
+        private: true
+    - zone
+    - instance_name
+    - instanceName:
+        default: ${get('instance_name', '')}
+        required: false
+        private: true
+    - access_token:
+        sensitive: true
+    - accessToken:
+        default: ${get('access_token', '')}
+        required: false
+        private: true
+        sensitive: true
+    - machine_type
+    - machineType:
+        default: ${get('machine_type', '')}
+        required: false
+        private: true
+    - async:
+        default: 'true'
+        required: false
+    - timeout:
+        default: '30'
+        required: false
+    - polling_interval:
+        default: '1'
+        required: false
+    - pollingInterval:
+        default: ${get('polling_interval', '')}
+        required: false
+        private: true
+    - proxy_host:
+        default: ''
+        required: false
+    - proxyHost:
+        default: ${get('proxy_host', '')}
+        required: false
+        private: true
+    - proxy_port:
+        default: '8080'
+        required: false
+    - proxyPort:
+        default: ${get('proxy_port', '')}
+        required: false
+        private: true
+    - proxy_username:
+        default: ''
+        required: false
+    - proxyUsername:
+        default: ${get('proxy_username', '')}
+        required: false
+        private: true
+    - proxy_password:
+        default: ''
+        required: false
+        sensitive: true
+    - proxyPassword:
+        default: ${get('proxy_password', '')}
+        required: false
+        private: true
+        sensitive: true
+    - pretty_print:
+        default: 'true'
+        required: false
+    - prettyPrint:
+        default: ${get('pretty_print', '')}
+        required: false
+        private: true
+
+  java_action:
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesSetMachineType
+    method_name: execute
+
+  outputs:
+    - return_code: ${returnCode}
+    - return_result: ${returnResult}
+    - exception: ${get('exception', '')}
+    - status
+    - zone_operation_name: ${zoneOperationName}
+    - instance_name_out: ${get('instanceName','')}
+    - instance_details: ${get('instanceDetails','')}
+    - machine_type_out: ${get('machineType','')}
+
+
+  results:
+    - SUCCESS: ${returnCode=='0'}
+    - FAILURE

--- a/content/io/cloudslang/google/compute/compute_engine/instances/start_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/start_instance.sl
@@ -142,7 +142,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesStart
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/start_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/start_instance.sl
@@ -18,6 +18,20 @@
 #! @input instance_name: Name of the Instance resource to start.
 #!                      Example: 'operation-1234'
 #! @input access_token: The access token from get_access_token.
+#! @input async: Boolean specifying whether the operation to run sync or async.
+#!               Valid: 'true', 'false'
+#!               Default: 'true'
+#!               Optional
+#! @input timeout: The time, in seconds, to wait for a response if the async input is set to "false".
+#!                 If the value is 0, the operation will wait until zone operation progress is 100.
+#!                 Valid: Any positive number including 0.
+#!                 Default: '30'
+#!                 Optional
+#! @input polling_interval: The time, in seconds, to wait before a new request that verifies if the operation finished
+#!                          is executed, if the async input is set to "false".
+#!                          Valid values: Any positive number including 0.
+#!                          Default: '1'
+#!                          Optional
 #! @input proxy_host: Proxy server used to access the provider services.
 #!                    Optional
 #! @input proxy_port: Proxy server port used to access the provider services.
@@ -36,6 +50,9 @@
 #! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
 #! @output exception: Exception if there was an error when executing, empty otherwise.
 #! @output zone_operation_name: Contains the ZoneOperation name, if the returnCode is '0', otherwise it is empty.
+#! @output instance_name_out: The name of the instance.
+#! @output instance_details: Details about the instance if async is false.
+#! @output status: The status of the instance if async is false, otherwise the status of the ZoneOperation.
 #!
 #! @result SUCCESS: The request for the Instance to start was successfully sent.
 #! @result FAILURE: An error occurred while trying to send the request.
@@ -67,6 +84,19 @@ operation:
         required: false
         private: true
         sensitive: true
+    - async:
+        default: 'true'
+        required: false
+    - timeout:
+        default: '30'
+        required: false
+    - polling_interval:
+        default: '1'
+        required: false
+    - pollingInterval:
+        default: ${get('polling_interval', '')}
+        required: false
+        private: true
     - proxy_host:
         default: ''
         required: false
@@ -115,6 +145,9 @@ operation:
     - return_result: ${returnResult}
     - exception: ${get('exception', '')}
     - zone_operation_name: ${zoneOperationName}
+    - instance_name_out: ${get('instanceName', '')}
+    - instance_details: ${get('instanceDetails', '')}
+    - status
 
   results:
     - SUCCESS: ${returnCode=='0'}

--- a/content/io/cloudslang/google/compute/compute_engine/instances/start_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/start_instance.sl
@@ -106,7 +106,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesStart
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/stop_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/stop_instance.sl
@@ -142,7 +142,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesStop
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/instances/stop_instance.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/instances/stop_instance.sl
@@ -106,7 +106,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesStop
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/networks/delete_network.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/networks/delete_network.sl
@@ -7,9 +7,9 @@
 #
 ########################################################################################################################
 #!!
-#! @description: This operation can be used to delete a Network resource. The operation returns a ZoneOperation resource
-#!               as a JSON object, that can be used to retrieve the status and progress of the ZoneOperation, using the
-#!               ZoneOperationsGet operation.
+#! @description: This operation can be used to delete a Network resource. The operation returns a GlobalOperation resource
+#!               as a JSON object, that can be used to retrieve the status and progress of the GlobalOperation, using the
+#!               GlobalOperationsGet operation.
 #!
 #! @input project_id: Google Cloud project name.
 #!                    Example: 'example-project-a'
@@ -30,10 +30,11 @@
 #!                      Default: 'true'
 #!                      Optional
 #!
-#! @output return_result: Contains the ZoneOperation resource, as a JSON object.
+#! @output return_result: Contains the GlobalOperation resource, as a JSON object.
 #! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
 #! @output exception: Exception if there was an error when executing, empty otherwise.
-#! @output zone_operation_name: Contains the ZoneOperation name, if the returnCode is '0', otherwise it is empty.
+#! @output global_operation_name: Contains the GlobalOperation name, if the returnCode is '0', otherwise it is empty.
+#! @output status: The status of the operation if async is true, otherwise the status of the instance.
 #!
 #! @result SUCCESS: The request for the Network to be deleted was successfully sent.
 #! @result FAILURE: An error occurred while trying to send the request.
@@ -103,7 +104,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.networks.NetworksDelete
     method_name: execute
 
@@ -111,7 +112,8 @@ operation:
     - return_code: ${returnCode}
     - return_result: ${returnResult}
     - exception: ${get('exception', '')}
-    - zone_operation_name: ${zoneOperationName}
+    - global_operation_name: ${globalOperationName}
+    - status
 
   results:
     - SUCCESS: ${returnCode=='0'}

--- a/content/io/cloudslang/google/compute/compute_engine/networks/delete_network.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/networks/delete_network.sl
@@ -110,7 +110,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.networks.NetworksDelete
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/networks/get_network.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/networks/get_network.sl
@@ -106,7 +106,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.networks.NetworksGet
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/networks/get_network.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/networks/get_network.sl
@@ -100,7 +100,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.networks.NetworksGet
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/networks/insert_network.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/networks/insert_network.sl
@@ -172,7 +172,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.networks.NetworksInsert
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/networks/insert_network.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/networks/insert_network.sl
@@ -28,6 +28,20 @@
 #!                                 10.128.0.0/9 and it automatically creates one subnetwork per region.
 #!                                 Note: If <ipV4RangeInp> is set, then this input is ignored.
 #!                                 Optional
+#! @input async: Boolean specifying whether the operation to run sync or async.
+#!               Valid: 'true', 'false'
+#!               Default: 'true'
+#!               Optional
+#! @input timeout: The time, in seconds, to wait for a response if the async input is set to "false".
+#!                 If the value is 0, the operation will wait until global operation progress is 100.
+#!                 Valid: Any positive number including 0.
+#!                 Default: '30'
+#!                 Optional
+#! @input polling_interval: The time, in seconds, to wait before a new request that verifies if the operation finished
+#!                          is executed, if the async input is set to "false".
+#!                          Valid values: Any positive number including 0.
+#!                          Default: '1'
+#!                          Optional
 #! @input proxy_host: Proxy server used to access the provider services.
 #!                    Optional
 #! @input proxy_port: Proxy server port used to access the provider services.
@@ -42,10 +56,13 @@
 #!                      Default: 'true'
 #!                      Optional
 #!
-#! @output return_result: Contains the ZoneOperation resource, as a JSON object.
+#! @output return_result: Contains the GlobalOperation resource, as a JSON object.
 #! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
 #! @output exception: Exception if there was an error when executing, empty otherwise.
-#! @output zone_operation_name: Contains the ZoneOperation name, if the returnCode is '0', otherwise it is empty.
+#! @output global_operation_name: Contains the GlobalOperation name, if the returnCode is '0', otherwise it is empty.
+#! @output network_name_out: The name of the newly created network if async is true, otherwise empty.
+#! @output network_id: The id of the newly created network if async is true, otherwise empty.
+#! @output status: The status of the operation if async is true, otherwise the status of the instance.
 #!
 #! @result SUCCESS: The request for the Network to be inserted was successfully sent.
 #! @result FAILURE: An error occurred while trying to send the request.
@@ -97,6 +114,19 @@ operation:
         default: ${get('ip_v_4_range', '')}
         required: false
         private: true
+    - async:
+        default: 'true'
+        required: false
+    - timeout:
+        default: '30'
+        required: false
+    - polling_interval:
+        default: '1'
+        required: false
+    - pollingInterval:
+        default: ${get('polling_interval', '')}
+        required: false
+        private: true
     - proxy_host:
         default: ''
         required: false
@@ -136,7 +166,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.networks.NetworksInsert
     method_name: execute
 
@@ -144,7 +174,10 @@ operation:
     - return_code: ${returnCode}
     - return_result: ${returnResult}
     - exception: ${get('exception', '')}
-    - zone_operation_name: ${zoneOperationName}
+    - global_operation_name: ${globalOperationName}
+    - network_name_out: ${networkName}
+    - network_id: ${networkId}
+    - status
 
   results:
     - SUCCESS: ${returnCode=='0'}

--- a/content/io/cloudslang/google/compute/compute_engine/networks/list_networks.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/networks/list_networks.sl
@@ -129,7 +129,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.networks.NetworksList
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/networks/list_networks.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/networks/list_networks.sl
@@ -135,7 +135,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.networks.NetworksList
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/operations/global_operations_get.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/operations/global_operations_get.sl
@@ -7,13 +7,11 @@
 #
 ########################################################################################################################
 #!!
-#! @description: This operation can be used to retrieve a ZoneOperation resource, as JSON object.
+#! @description: This operation can be used to retrieve a GlobalOperation resource, as JSON object.
 #!
 #! @input project_id: Google Cloud project name.
 #!                    Example: 'example-project-a'
-#! @input zone: The name of the zone in which the instance lives.
-#!              Examples: 'us-central1-a', 'us-central1-b', 'us-central1-c'
-#! @input zone_operation_name: Name of the ZoneOperation resource to return.
+#! @input global_operation_name: Name of the GlobalOperation resource to return.
 #!                             Example: 'operation-1234'
 #! @input access_token: The access token returned by the get_access_token operation, with at least one of the following
 #!                      scopes: 'https://www.googleapis.com/auth/compute.readonly',
@@ -33,20 +31,20 @@
 #!                      Default: 'true'
 #!                      Optional
 #!
-#! @output return_result: Contains the ZoneOperation resource, as a JSON object.
-#! @output status: The status of the ZoneOperation resource: 'PENDING', 'RUNNING' or 'DONE'.
+#! @output return_result: Contains the GlobalOperation resource, as a JSON object.
+#! @output status: The status of the GlobalOperation resource: 'PENDING', 'RUNNING' or 'DONE'.
 #! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
 #! @output exception: Exception if there was an error when executing, empty otherwise.
 #!
-#! @result SUCCESS: The ZoneOperation resource has been successfully retrieved.
-#! @result FAILURE: An error occurred while trying to get the ZoneOperation resource.
+#! @result SUCCESS: The GlobalOperation resource has been successfully retrieved.
+#! @result FAILURE: An error occurred while trying to get the GlobalOperation resource.
 #!!#
 ########################################################################################################################
 
-namespace: io.cloudslang.google.compute.compute_engine.zone_operations
+namespace: io.cloudslang.google.compute.compute_engine.operations
 
 operation:
-  name: zone_operations_get
+  name: global_operations_get
 
   inputs:
     - project_id
@@ -54,12 +52,11 @@ operation:
         default: ${get('project_id', '')}
         required: false
         private: true
-    - zone
-    - zone_operation_name:
+    - global_operation_name:
         default: ''
         required: false
-    - zoneOperationName:
-        default: ${get('zone_operation_name', '')}
+    - globalOperationName:
+        default: ${get('global_operation_name', '')}
         required: false
         private: true
     - access_token:
@@ -108,8 +105,8 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
-    class_name: io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesGet
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    class_name: io.cloudslang.content.google.actions.compute.compute_engine.operations.GlobalOperationsGet
     method_name: execute
 
   outputs:

--- a/content/io/cloudslang/google/compute/compute_engine/operations/global_operations_get.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/operations/global_operations_get.sl
@@ -105,7 +105,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.operations.GlobalOperationsGet
     method_name: execute
 

--- a/content/io/cloudslang/google/compute/compute_engine/operations/zone_operations_get.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/operations/zone_operations_get.sl
@@ -1,15 +1,24 @@
+#   (c) Copyright 2017 Hewlett-Packard Enterprise Development Company, L.P.
+#   All rights reserved. This program and the accompanying materials
+#   are made available under the terms of the Apache License v2.0 which accompany this distribution.
+#
+#   The Apache License is available at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
 ########################################################################################################################
 #!!
-#! @description: This operation deletes a disk resource from the specified project using the data included as inputs.
+#! @description: This operation can be used to retrieve a ZoneOperation resource, as JSON object.
 #!
 #! @input project_id: Google Cloud project name.
 #!                    Example: 'example-project-a'
 #! @input zone: The name of the zone in which the instance lives.
 #!              Examples: 'us-central1-a', 'us-central1-b', 'us-central1-c'
-#! @input access_token: The access token from get_access_token.
-#! @input instance_name: The name that the new instance will have.
-#!                       Example: 'instance-1234'
-#! @input device_name: The disk device name to detach.
+#! @input zone_operation_name: Name of the ZoneOperation resource to return.
+#!                             Example: 'operation-1234'
+#! @input access_token: The access token returned by the get_access_token operation, with at least one of the following
+#!                      scopes: 'https://www.googleapis.com/auth/compute.readonly',
+#!                              'https://www.googleapis.com/auth/compute',
+#!                              'https://www.googleapis.com/auth/cloud-platform'.
 #! @input proxy_host: Proxy server used to access the provider services.
 #!                    Optional
 #! @input proxy_port: Proxy server port used to access the provider services.
@@ -24,45 +33,42 @@
 #!                      Default: 'true'
 #!                      Optional
 #!
-#! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
 #! @output return_result: Contains the ZoneOperation resource, as a JSON object.
+#! @output status: The status of the ZoneOperation resource: 'PENDING', 'RUNNING' or 'DONE'.
+#! @output return_code: '0' if operation was successfully executed, '-1' otherwise.
 #! @output exception: Exception if there was an error when executing, empty otherwise.
-#! @output zone_operation_name: Contains the ZoneOperation name, if the returnCode is '0', otherwise it is empty.
 #!
-#! @result SUCCESS: The request to detach the Disk from an Instance was successfully sent.
-#! @result FAILURE: An error occurred while trying to send the request.
+#! @result SUCCESS: The ZoneOperation resource has been successfully retrieved.
+#! @result FAILURE: An error occurred while trying to get the ZoneOperation resource.
 #!!#
 ########################################################################################################################
 
-namespace: io.cloudslang.google.compute.compute_engine.instances
+namespace: io.cloudslang.google.compute.compute_engine.operations
 
-operation: 
-  name: detach_disk_from_instance
-  
-  inputs: 
-    - access_token:    
+operation:
+  name: zone_operations_get
+
+  inputs:
+    - project_id
+    - projectId:
+        default: ${get('project_id', '')}
+        required: false
+        private: true
+    - zone
+    - zone_operation_name:
+        default: ''
+        required: false
+    - zoneOperationName:
+        default: ${get('zone_operation_name', '')}
+        required: false
+        private: true
+    - access_token:
         sensitive: true
-    - accessToken: 
-        default: ${get('access_token', '')}  
-        required: false 
-        private: true 
+    - accessToken:
+        default: ${get('access_token', '')}
+        required: false
+        private: true
         sensitive: true
-    - project_id    
-    - projectId: 
-        default: ${get('project_id', '')}  
-        required: false 
-        private: true 
-    - zone    
-    - instance_name    
-    - instanceName: 
-        default: ${get('instance_name', '')}  
-        required: false 
-        private: true 
-    - device_name    
-    - deviceName: 
-        default: ${get('device_name', '')}  
-        required: false 
-        private: true 
     - proxy_host:
         default: ''
         required: false
@@ -100,18 +106,18 @@ operation:
         default: ${get('pretty_print', '')}
         required: false
         private: true
-    
-  java_action: 
-    gav: 'io.cloudslang.content:cs-google:0.2.1'
-    class_name: 'io.cloudslang.content.google.actions.compute.compute_engine.instances.InstancesDetachDisk'
-    method_name: 'execute'
-  
-  outputs: 
+
+  java_action:
+    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    class_name: io.cloudslang.content.google.actions.compute.compute_engine.operations.ZoneOperationsGet
+    method_name: execute
+
+  outputs:
     - return_code: ${returnCode}
+    - status: ${status}
     - return_result: ${returnResult}
     - exception: ${get('exception', '')}
-    - zone_operation_name: ${zoneOperationName} 
-  
-  results: 
-    - SUCCESS: ${returnCode=='0'} 
+
+  results:
+    - SUCCESS: ${returnCode=='0'}
     - FAILURE

--- a/content/io/cloudslang/google/compute/compute_engine/operations/zone_operations_get.sl
+++ b/content/io/cloudslang/google/compute/compute_engine/operations/zone_operations_get.sl
@@ -114,7 +114,7 @@ operation:
         private: true
 
   java_action:
-    gav: 'io.cloudslang.content:cs-google:0.4.1'
+    gav: 'io.cloudslang.content:cs-google:0.4.2'
     class_name: io.cloudslang.content.google.actions.compute.compute_engine.operations.ZoneOperationsGet
     method_name: execute
 


### PR DESCRIPTION
performed following updates for google cloud compute engine:
 - updated gav version to 'io.cloudslang.content:cs-google:0.4.1'
 - added global_operation_get operation in operations
 - added get_serial_port_output, reset_windows_password and set_machine_type in instances
 - moved attach/detach_disk_to/from_instance in disks folder
 - updated inputs/outputs/description for all operation under the folders: disks, instances, networks, operations
 - renamed zone_operations -> operations
Signed-off-by: Victor Ursan <victor.ursan@gmail.com>