### PR TITLE
Update CloudSlang version to latest (1.0.22)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
   - docker info
   - docker version
   - df -kh
-  - wget https://github.com/CloudSlang/cloud-slang/releases/download/cloudslang-1.0.16/cslang-builder.zip
+  - wget https://github.com/CloudSlang/cloud-slang/releases/download/cloudslang-1.0.22/cslang-builder.zip
   - unzip -q cslang-builder.zip
   - chmod +x cslang-builder/bin/cslang-builder
   - ./cslang-builder/bin/cslang-builder -ts ${SUITE},\!default -cov -des -cs


### PR DESCRIPTION
PR for travis build tests.