### PR TITLE
Feature UCMDB bug fixes

### DIFF
--- a/content/io/cloudslang/microfocus/ucmdb/get_object_attributes_by_id.sl
+++ b/content/io/cloudslang/microfocus/ucmdb/get_object_attributes_by_id.sl
@@ -80,9 +80,9 @@ flow:
         default: http
         required: false
     - username:
-        required: false
+        required: true
     - password:
-        required: false
+        required: true
         sensitive: true
     - object_id
     - object_type
@@ -129,6 +129,9 @@ flow:
             - method: POST
         publish:
           - json_token: '${return_result}'
+          - error_message
+          - return_code
+          - return_result
         navigate:
           - SUCCESS: get_value
           - FAILURE: FAILURE
@@ -139,6 +142,9 @@ flow:
             - json_path: token
         publish:
           - token: '${return_result}'
+          - return_result
+          - return_code
+          - error_message
         navigate:
           - SUCCESS: get_ci
           - FAILURE: FAILURE
@@ -162,6 +168,9 @@ flow:
             - method: GET
         publish:
           - ci_output: '${return_result}'
+          - return_result
+          - error_message
+          - return_code
         navigate:
           - SUCCESS: get_properties
           - FAILURE: FAILURE
@@ -172,6 +181,9 @@ flow:
             - json_path: properties
         publish:
           - ci_output: '${return_result}'
+          - return_result
+          - return_code
+          - error_message
         navigate:
           - SUCCESS: parse_attribute_list
           - FAILURE: FAILURE

--- a/content/io/cloudslang/microfocus/ucmdb/get_object_attributes_by_id.sl
+++ b/content/io/cloudslang/microfocus/ucmdb/get_object_attributes_by_id.sl
@@ -200,8 +200,8 @@ flow:
   outputs:
     - return_result: '${return_result}'
     - return_code: '${return_code}'
-    - exception: '${exception}'
-    - attributes
+    - exception: '${error_message}'
+    - attributes: "${get('attributes', ' ')}"
   results:
     - FAILURE
     - SUCCESS

--- a/content/io/cloudslang/microfocus/ucmdb/get_object_attributes_by_id.sl
+++ b/content/io/cloudslang/microfocus/ucmdb/get_object_attributes_by_id.sl
@@ -198,9 +198,9 @@ flow:
           - FAILURE: FAILURE
           - SUCCESS: SUCCESS
   outputs:
-    - return_result
-    - return_code
-    - exception
+    - return_result: '${return_result}'
+    - return_code: '${return_code}'
+    - exception: '${exception}'
     - attributes
   results:
     - FAILURE

--- a/content/io/cloudslang/microfocus/ucmdb/modify_object_attributes.sl
+++ b/content/io/cloudslang/microfocus/ucmdb/modify_object_attributes.sl
@@ -28,9 +28,7 @@
 #! @input password: The password associated with the 'username' input value.
 #! @input object_id: The identifier of the object to query.
 #! @input object_type: The type of the object to query.
-#! @input property_list: A property to set (name=value), The type of the property will be automatically determined.
-#!                       Additional properties can be added by making extra prop inputs with a number appended, such
-#!                       as prop1.
+#! @input property_list: A comma delimited list of properties to set (name=value). The type of the property will be automatically determined.
 #! @input trust_all_roots: Specifies whether to enable weak security over SSL/TSL. A certificate is trusted even if no
 #!                         trusted certification authority issued it.
 #!                         Valid: 'true' or 'false'.
@@ -144,6 +142,8 @@ flow:
         publish:
           - token: '${return_result}'
           - return_result
+          - return_code
+          - error_message
         navigate:
           - SUCCESS: separate_attributes_list
           - FAILURE: FAILURE

--- a/content/io/cloudslang/microfocus/ucmdb/modify_object_attributes.sl
+++ b/content/io/cloudslang/microfocus/ucmdb/modify_object_attributes.sl
@@ -189,7 +189,7 @@ flow:
           - FAILURE: FAILURE
           - SUCCESS: modify_selected_attributes
   outputs:
-    - return_result
+    - return_result: '${return_result}'
     - return_code: '${return_code}'
     - exception: '${error_message}'
     - ci_update_summary: "${get('json_result', ' ')}"

--- a/content/io/cloudslang/microfocus/ucmdb/utility/parse_attribute_list.sl
+++ b/content/io/cloudslang/microfocus/ucmdb/utility/parse_attribute_list.sl
@@ -116,7 +116,7 @@ flow:
           - SUCCESS: SUCCESS
           - FAILURE: FAILURE
   outputs:
-    - attributes_list: '${attributes}'
+    - attributes_list: "${get('attributes', ' ')}"
     - return_result: '${return_result}'
     - return_code: '${return_code}'
     - exception: '${exception}'

--- a/content/io/cloudslang/microfocus/ucmdb/utility/parse_attribute_list.sl
+++ b/content/io/cloudslang/microfocus/ucmdb/utility/parse_attribute_list.sl
@@ -20,6 +20,9 @@
 #! @input attributes: Auxiliary input, should not receive a value.
 #!
 #! @output attributes_list: A list of attribute and attribute value in comma delimited pairs.
+#! @output return_result: The result of the execution.
+#! @output return_code: '0' if success, '-1' otherwise.
+#! @output exception: Exception if there was an error when executing, empty otherwise.
 #!
 #! @result FAILURE: The operation completed unsuccessfully.
 #! @result SUCCESS: The operation completed as stated in the description.

--- a/content/io/cloudslang/microfocus/ucmdb/utility/parse_json_keys.sl
+++ b/content/io/cloudslang/microfocus/ucmdb/utility/parse_json_keys.sl
@@ -1,0 +1,129 @@
+#   Copyright 2018, Micro Focus, L.P.
+#   All rights reserved. This program and the accompanying materials
+#   are made available under the terms of the Apache License v2.0 which accompany this distribution.
+#
+#   The Apache License is available at
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+########################################################################################################################
+#!!
+#! @description: Parse a json and retrieves all its keys.
+#!
+#! @input json: The json from which the keys are extracted.
+#!
+#! @output attribute_key_list: A comma delimited list of all keys from the json.
+#!!#
+########################################################################################################################
+namespace: io.cloudslang.microfocus.ucmdb.utility
+flow:
+  name: parse_json_keys
+  inputs:
+    - json
+  workflow:
+    - get_keys:
+        do:
+          io.cloudslang.base.maps.get_keys:
+            - map: '${json}'
+        publish:
+          - result
+        navigate:
+          - SUCCESS: replace_square_bracket
+    - replace_square_bracket:
+        do:
+          io.cloudslang.base.strings.search_and_replace:
+            - origin_string: '${result}'
+            - text_to_replace: '['
+            - replace_with: ''
+        publish:
+          - replaced_string
+        navigate:
+          - SUCCESS: replace_square_bracket_2
+          - FAILURE: FAILURE
+    - replace_square_bracket_2:
+        do:
+          io.cloudslang.base.strings.search_and_replace:
+            - origin_string: '${replaced_string}'
+            - text_to_replace: ']'
+            - replace_with: ''
+        publish:
+          - attribute_list: '${replaced_string}'
+        navigate:
+          - SUCCESS: remove_quotes
+          - FAILURE: FAILURE
+    - remove_quotes:
+        do:
+          io.cloudslang.base.strings.regex_replace:
+            - regex: "'"
+            - text: '${attribute_list}'
+            - replacement: ''
+        publish:
+          - attribute_list: '${result_text}'
+        navigate:
+          - SUCCESS: remove_space
+    - remove_space:
+        do:
+          io.cloudslang.base.strings.search_and_replace:
+            - origin_string: '${attribute_list}'
+            - text_to_replace: ' '
+            - replace_with: ''
+        publish:
+          - attribute_list: '${replaced_string}'
+        navigate:
+          - SUCCESS: SUCCESS
+          - FAILURE: FAILURE
+  outputs:
+    - attribute_key_list: '${attribute_list}'
+  results:
+    - FAILURE
+    - SUCCESS
+extensions:
+  graph:
+    steps:
+      get_keys:
+        x: 156
+        y: 125
+      replace_square_bracket:
+        x: 331
+        y: 121
+        navigate:
+          94ed1400-0d01-0ebd-c6c8-029b0eafb53a:
+            targetId: 1b397386-d927-6dc3-44d8-cade9e2663a3
+            port: FAILURE
+      replace_square_bracket_2:
+        x: 507
+        y: 122
+        navigate:
+          86891ff4-d373-cb2f-5065-b829c2f04776:
+            targetId: 1b397386-d927-6dc3-44d8-cade9e2663a3
+            port: FAILURE
+            vertices:
+              - x: 542
+                y: 201
+      remove_quotes:
+        x: 679
+        y: 126
+      remove_space:
+        x: 854
+        y: 126
+        navigate:
+          cc3dd103-16d6-67c5-af48-3e41a46af500:
+            targetId: 1b397386-d927-6dc3-44d8-cade9e2663a3
+            port: FAILURE
+          7a120529-eda7-2a2d-df25-cbf01c8374a6:
+            targetId: da208c32-0b8c-f9b7-ccd6-b1ddf8004de6
+            port: SUCCESS
+    results:
+      FAILURE:
+        1b397386-d927-6dc3-44d8-cade9e2663a3:
+          x: 507
+          y: 337
+      SUCCESS:
+        da208c32-0b8c-f9b7-ccd6-b1ddf8004de6:
+          x: 1034
+          y: 135

--- a/content/io/cloudslang/microfocus/ucmdb/utility/parse_json_keys.sl
+++ b/content/io/cloudslang/microfocus/ucmdb/utility/parse_json_keys.sl
@@ -18,6 +18,9 @@
 #! @input json: The json from which the keys are extracted.
 #!
 #! @output attribute_key_list: A comma delimited list of all keys from the json.
+#!
+#! @result FAILURE: The operation completed unsuccessfully.
+#! @result SUCCESS: The operation completed as stated in the description.
 #!!#
 ########################################################################################################################
 namespace: io.cloudslang.microfocus.ucmdb.utility


### PR DESCRIPTION
1. Made the username/password required inputs for ```get_object_attributes_by_id``` as the UCMDB operations fails without them
2. If attribute_list input is empty, all attributes are returned to the user for the flow ```get_object_attributes_by_id```
For this I added a new utility flow ```parse_json_keys``` that gets all the keys from the json, then constructs the output list by extracting the value for each key one by one using the ```parse_attribute_list``` utility flow
3. Exposed more outputs

Cloudslang builder output:
```
[INFO ] 2018/09/26 15:24:10 LoggingServiceImpl -
[INFO ] 2018/09/26 15:24:10 LoggingServiceImpl - ------------------------------------------------------------
[INFO ] 2018/09/26 15:24:10 LoggingServiceImpl - BUILD SUCCESS
[INFO ] 2018/09/26 15:24:10 LoggingServiceImpl - ------------------------------------------------------------
[INFO ] 2018/09/26 15:24:10 LoggingServiceImpl - Found 663 slang files under directory: "./content" and all are valid.
[INFO ] 2018/09/26 15:24:10 LoggingServiceImpl - 0 test cases passed
[INFO ] 2018/09/26 15:24:10 LoggingServiceImpl - 792 test cases skipped
[INFO ] 2018/09/26 15:24:10 LoggingServiceImpl -
```