### PR TITLE
Ucmdb feature bug fixes

### DIFF
--- a/content/io/cloudslang/microfocus/ucmdb/utility/parse_attribute_list.sl
+++ b/content/io/cloudslang/microfocus/ucmdb/utility/parse_attribute_list.sl
@@ -55,7 +55,7 @@ flow:
     - string_equals:
         do:
           io.cloudslang.base.strings.string_equals:
-            - first_string: '${get_all}'
+            - first_string: '${return_result}'
             - second_string: all
         publish: []
         navigate:


### PR DESCRIPTION
Any attribute passed to the get_object_attributes_by_id flow returns all attributes in the output flow instead of just the specific one asked by the user.
Solution is checking against the ```return_result``` instead of ```get_all```.

Mismatch occurred because testing was done in web designer, but when coping back into IDE this change was missed.