### PR TITLE
Http_client_action_fix

### DIFF
--- a/content/io/cloudslang/base/http/http_client_action.sl
+++ b/content/io/cloudslang/base/http/http_client_action.sl
@@ -378,8 +378,8 @@ operation:
   outputs:
     - return_result: ${get('returnResult', '')}
     - error_message: ${returnResult if returnCode != '0' else ''}
-    - return_code: ${returnCode}
     - status_code: ${get('statusCode', '')}
+    - return_code: ${returnCode if (str(status_code) in valid_http_status_codes) else '-1'}
     - response_headers: ${get('responseHeaders', '')}
 
   results:


### PR DESCRIPTION
Added an expression for "return_code output" in order to check for "valid_http_status_codes" input, and if it fails to match the input value / range, will return '-1'.

Signed-off-by: petmariu <marius.petrovan@hpe.com>