### PR TITLE
Mark output as sensitive using workaround

### DIFF
--- a/content/io/cloudslang/microfocus/hcm/aws_service_catalog/utils/get_subscription_params.sl
+++ b/content/io/cloudslang/microfocus/hcm/aws_service_catalog/utils/get_subscription_params.sl
@@ -16,6 +16,7 @@
 #!                   Optional
 #! @input username: The user name used for authentication.
 #!                  Optional
+#! @input input_sec: Used for marking the output as sensitive
 #! @input password: The password used for authentication.
 #!                  Optional
 #! @input proxy_host: The proxy server used to access the web site.

--- a/content/io/cloudslang/microfocus/hcm/aws_service_catalog/utils/get_subscription_params.sl
+++ b/content/io/cloudslang/microfocus/hcm/aws_service_catalog/utils/get_subscription_params.sl
@@ -198,7 +198,10 @@ operation:
         default: ${get('query_params', '')}  
         required: false 
         private: true 
-
+    - input_sec:
+        default: ''
+        required: false
+        sensitive: true
   java_action: 
     gav: 'io.cloudslang.content:cs-microfocus-hcm:1.0.0'
     class_name: 'io.cloudslang.content.hcm.actions.utils.GetSubscriptionParamsAction'
@@ -208,7 +211,7 @@ operation:
     - return_code: ${get('returnCode', '')} 
     - return_result: ${get('returnResult', '')} 
     - exception: ${get('exception', '')} 
-    - param_list: ${get('paramList', '')}
+    - param_list: ${get('paramList', '') + input_sec}
   
   results: 
     - SUCCESS: ${returnCode=='0'} 

--- a/content/io/cloudslang/microfocus/hcm/aws_service_catalog/utils/get_subscription_params.sl
+++ b/content/io/cloudslang/microfocus/hcm/aws_service_catalog/utils/get_subscription_params.sl
@@ -203,6 +203,7 @@ operation:
         default: ''
         required: false
         sensitive: true
+        private: true
   java_action: 
     gav: 'io.cloudslang.content:cs-microfocus-hcm:1.0.0'
     class_name: 'io.cloudslang.content.hcm.actions.utils.GetSubscriptionParamsAction'


### PR DESCRIPTION
Mark provisioning_parameters as sensitive to not expose passwords and others sensitive information to the user in central 
Signed-off-by: mateii <ioana.matei@microfocus.com>