### PR TITLE
Changed send_mail's input 'headers' to public

### DIFF
--- a/content/io/cloudslang/base/mail/send_mail.sl
+++ b/content/io/cloudslang/base/mail/send_mail.sl
@@ -137,7 +137,6 @@ operation:
         required: false
     - headers:
         required: false
-        private: true
     - row_delimiter:
         required: false
     - rowDelimiter:


### PR DESCRIPTION
When opening the **send_mail** operation the Inputs section was annotated with the following warning: Private input "headers" must have a default value. That is because **headers** input was marked as private even though it shouldn't.

A defect for this was raised.

Checked in Designer that the below solution solved the problem.