### PR TITLE
Expose endpoint input at the step level

### DIFF
--- a/content/io/cloudslang/amazon/aws/ec2/deploy_instance.sl
+++ b/content/io/cloudslang/amazon/aws/ec2/deploy_instance.sl
@@ -479,6 +479,7 @@ flow:
           do:
             instances.check_instance_state:
               - identity
+             -  endpoint
               - credential
               - proxy_host
               - proxy_port
@@ -501,6 +502,7 @@ flow:
         do:
           tags.create_tags:
             - identity
+            -  endpoint
             - credential
             - proxy_host
             - proxy_port
@@ -524,6 +526,7 @@ flow:
           do:
             instances.terminate_instances:
               - identity
+              -  endpoint
               - credential
               - proxy_host
               - proxy_port
@@ -545,6 +548,7 @@ flow:
         do:
           instances.describe_instances:
             - identity
+            - endpoint
             - credential
             - proxy_host
             - proxy_port

--- a/content/io/cloudslang/amazon/aws/ec2/deploy_instance.sl
+++ b/content/io/cloudslang/amazon/aws/ec2/deploy_instance.sl
@@ -479,7 +479,7 @@ flow:
           do:
             instances.check_instance_state:
               - identity
-             -  endpoint
+              - endpoint
               - credential
               - proxy_host
               - proxy_port
@@ -502,7 +502,7 @@ flow:
         do:
           tags.create_tags:
             - identity
-            -  endpoint
+            - endpoint
             - credential
             - proxy_host
             - proxy_port
@@ -526,7 +526,7 @@ flow:
           do:
             instances.terminate_instances:
               - identity
-              -  endpoint
+              - endpoint
               - credential
               - proxy_host
               - proxy_port


### PR DESCRIPTION
Expose endpoint input at the step level so that users will be able to deploy AWS EC2 instances in custom regions.