### PR TITLE
Fixed http status code in python

### DIFF
--- a/content/io/cloudslang/base/http/http_client_action.sl
+++ b/content/io/cloudslang/base/http/http_client_action.sl
@@ -393,7 +393,7 @@ operation:
         required: false
         private: true
     - valid_http_status_codes:
-        default: ${ str(range(200, 300)) }
+        default: ${ str(list(range(200, 300))) }
 
   java_action:
     gav: 'io.cloudslang.content:cs-http-client:0.1.76'


### PR DESCRIPTION
**Description:**
_HTTP Client Action_ was failing in OO 2020.08 for status code in range [201,299]. Fix works for both python and jython.

**Testing done**
Manual Testing in OO 2018.12 and 2020.08