### PR TITLE
Remove o_data_query default value.

### DIFF
--- a/content/io/cloudslang/microsoft/office365/get_email.sl
+++ b/content/io/cloudslang/microsoft/office365/get_email.sl
@@ -41,7 +41,7 @@
 #!                               &filter=HasAttachments eq true
 #!                               &search="from:help@contoso.com"
 #!                               &search="subject:Test"
-#!                      Default value: $select=subject,bodyPreview,sender,from
+#!                               $select=subject,bodyPreview,sender,from
 #!                      Optional
 #! @input file_path: The file path under which the attachment will be downloaded. The attachment will not be downloaded
 #!                   if a path is not provided.
@@ -147,7 +147,6 @@ operation:
         required: false
     - o_data_query:
         required: false
-        default: '$select=subject,bodyPreview,sender,from'
     - oDataQuery:
         default: ${get('o_data_query', '')}
         required: false


### PR DESCRIPTION
Currently, there is no way to specify no o_data_query when asking just for message_id. Even when left empty, the default value $select=subject,bodyPreview,sender,from is used.
It should be possible to specify this parameter to be empty.

